### PR TITLE
Fix operator precedence issue in DuckDB queries

### DIFF
--- a/duckdb/queries/0001_count_orders_from_terminal.sql
+++ b/duckdb/queries/0001_count_orders_from_terminal.sql
@@ -3,6 +3,6 @@ SELECT date_trunc('day', event_created) as day,
 FROM order_events
 WHERE event_created >= '2024-04-01' AND event_created < '2024-05-01'
   AND event_type = 'Departed'
-  AND event_payload ->> 'terminal' = 'Berlin'
+  AND (event_payload ->> 'terminal' = 'Berlin')
 GROUP BY day
 ORDER BY count desc, day;

--- a/duckdb/queries/0003_exists_order_delivered_from_terminal.sql
+++ b/duckdb/queries/0003_exists_order_delivered_from_terminal.sql
@@ -8,6 +8,6 @@ EXISTS (
     WHERE
         customer_id = 124
         AND event_type='Delivered'
-        AND event_payload->>'terminal' = 'London'
+        AND (event_payload->>'terminal' = 'London')
         AND event_created >= '2024-03-01' and event_created < '2024-04-01'
 );


### PR DESCRIPTION
Thanks for making this nice benchmark!

While running the benchmark locally, I noticed these two queries produce an error message in DuckDB currently due to an operator precedence issue in the parser which causes the queries to be evaluated incorrectly. Adding the explicit brackets works around this issue and fixes the queries to produce the correct result.
